### PR TITLE
Return email parameter to docker login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 1.0.1
-
-* Fix docker login during push to Docker Hub.
-
-## 1.0.0
+## 2.1
 
 * Package `oauth2_proxy` v2.1 with Alpine 3.4 base image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+* Fix docker login during push to Docker Hub.
+
 ## 1.0.0
 
 * Package `oauth2_proxy` v2.1 with Alpine 3.4 base image.

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,6 @@ deployment:
   tagged:
     tag: /.*/
     commands:
-      - docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker tag $IMAGE_NAME $IMAGE_NAME:$CIRCLE_TAG
       - docker push $IMAGE_NAME:$CIRCLE_TAG


### PR DESCRIPTION
We use Docker 1.10 on Circle CI which doesn't have that parameter deprecated. This parameter was removed in commit fec8ac0f8.
