### PR TITLE
Fix no certs bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1-2
+
+* Fix 500 Internal Error Internal Error when sending POST to Google
+  APIs.
+
 ## 2.1-1
 
 * Add SHA check of package.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM alpine:3.4
 
-ENV BUILD_PKGS="ca-certificates wget"
+ENV APP_PKGS="ca-certificates"
+ENV BUILD_PKGS="wget"
 
 ENV OAUTH2_PROXY_VERSION="2.1"
 ENV OAUTH2_PROXY_PKG="oauth2_proxy-${OAUTH2_PROXY_VERSION}.linux-amd64.go1.6" \
     OAUTH2_PROXY_SHA="3061e5b04bd14eeb9ec0ad1c9b324ba8d99d50eaadc5f528cdf4d21043828298"
 RUN apk update && \
     apk upgrade && \
-    apk add $BUILD_PKGS && \
+    apk add $APP_PKGS $BUILD_PKGS && \
     mkdir -p /var/tmp/oauth2_proxy && \
     cd /var/tmp/oauth2_proxy && \
     wget --progress=dot:mega https://github.com/bitly/oauth2_proxy/releases/download/v${OAUTH2_PROXY_VERSION}/${OAUTH2_PROXY_PKG}.tar.gz && \


### PR DESCRIPTION
Addresses "500 Internal Error Internal Error" caused by "failed to load system roots and no roots provided" issue. See #9.
